### PR TITLE
Add ability to summarize policy events

### DIFF
--- a/examples/get_secure_policy_events.py
+++ b/examples/get_secure_policy_events.py
@@ -2,37 +2,60 @@
 #
 # Get all policy events for a given time range or in the last N seconds.
 # The events are written in jsonl format to stdout.
+#
+# If --summarize is provided, summarize the policy events by sanitized
+# (removing container ids when present) description and print the
+# descriptions by decreasing frequency.  This allows you to see which policy
+# events are occurring most often.
+#
 # Progress information is written to standard error.
 #
 
 import os
 import sys
 import json
+import operator
+import re
+import getopt
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), '..'))
 from sdcclient import SdSecureClient
 
 def usage():
-    print 'usage: %s <sysdig-token> [<duration sec>|<from sec> <to sec>]' % sys.argv[0]
+    print 'usage: %s [-s|--summarize] [-l|--limit <limit>] <sysdig-token> [<duration sec>|<from sec> <to sec>]' % sys.argv[0]
+    print '-s|--summarize: group policy events by sanitized output and print by frequency'
+    print '-l|--limit: with -s, only print the first <limit> outputs'
     print 'You can find your token at https://secure.sysdig.com/#/settings/user'
     sys.exit(1)
 
+try:
+    opts, args = getopt.getopt(sys.argv[1:],"sl:",["summarize","limit="])
+except getopt.GetoptError:
+    usage()
+
+summarize = False
+limit = 0
+for opt, arg in opts:
+    if opt in ("-s", "--summarize"):
+        summarize = True
+    elif opt in ("-l", "--limit"):
+        limit = int(arg)
 #
 # Parse arguments
 #
-if len(sys.argv) < 3:
+if len(args) < 2:
     usage()
 
-sdc_token = sys.argv[1]
+sdc_token = args[0]
 
 duration = None
 from_sec = None
 to_sec = None
 
-if len(sys.argv) == 3:
-    duration = sys.argv[2]
-elif len(sys.argv) == 4:
-    from_sec = sys.argv[2]
-    to_sec = sys.argv[3]
+if len(args) == 2:
+    duration = args[1]
+elif len(args) == 3:
+    from_sec = args[1]
+    to_sec = args[2]
 else:
     usage()
 
@@ -45,6 +68,8 @@ if duration is not None:
     res = sdclient.get_policy_events_duration(duration)
 else:
     res = sdclient.get_policy_events_range(from_sec, to_sec)
+
+all_outputs = dict()
 
 while True:
 
@@ -61,6 +86,20 @@ while True:
     sys.stderr.write("offset={}\n".format(res[1]['ctx']['offset']))
 
     for event in res[1]['data']['policyEvents']:
-        sys.stdout.write(json.dumps(event) + "\n")
+        if summarize:
+            sanitize_output = re.sub(r'\S+\s\(id=\S+\)', '', event['output'])
+            all_outputs[sanitize_output] = all_outputs.get(sanitize_output, 0) + 1
+        else:
+            sys.stdout.write(json.dumps(event) + "\n")
 
     res = sdclient.get_more_policy_events(res[1]['ctx'])
+
+if summarize:
+    sorted = sorted(all_outputs.items(), key=operator.itemgetter(1), reverse=True)
+    count = 0
+    for val in sorted:
+        count += 1
+        sys.stdout.write("{} {}".format(val[1], val[0]))
+        if limit != 0 and count > limit:
+            break
+


### PR DESCRIPTION
Add the ability to summarize policy events by output string. This
removes any likely container information (xxx (id=yyy)) from output
strings, and then sorts by frequency descending.

New option --summarize controls whether to print summary or raw outputs,
and --limit allows you to print only the first <limit> entries.